### PR TITLE
Add team colors, adjust layout

### DIFF
--- a/src/data/teams.json
+++ b/src/data/teams.json
@@ -2,161 +2,193 @@
   {
     "name": "Anaheim Ducks",
     "hashtag": "FlyTogether",
-    "abbreviation": "ANA"
+    "abbreviation": "ANA",
+    "teamColor": "#F47A38"
   },
   {
     "name": "Arizona Coyotes",
     "hashtag": "Yotes",
-    "abbreviation": "ARI"
+    "abbreviation": "ARI",
+    "teamColor": "#FFB81C"
   },
   {
     "name": "Boston Bruins",
     "hashtag": "NHLBruins",
-    "abbreviation": "BOS"
+    "abbreviation": "BOS",
+    "teamColor": "#FFB81C"
   },
   {
     "name": "Buffalo Sabres",
     "hashtag": "LetsGoBuffalo",
-    "abbreviation": "BUF"
+    "abbreviation": "BUF",
+    "teamColor": "#002654"
   },
   {
     "name": "Calgary Flames",
     "hashtag": "Flames",
-    "abbreviation": "CGY"
+    "abbreviation": "CGY",
+    "teamColor": "#C8102E"
   },
   {
     "name": "Carolina Hurricanes",
     "hashtag": "CauseChaos",
-    "abbreviation": "CAR"
+    "abbreviation": "CAR",
+    "teamColor": "#CC0000"
   },
   {
     "name": "Chicago Blackhawks",
     "hashtag": "Blackhawks",
-    "abbreviation": "CHI"
+    "abbreviation": "CHI",
+    "teamColor": "#CF0A2C"
   },
   {
     "name": "Colorado Avalanche",
     "hashtag": "GoAvsGo",
-    "abbreviation": "COL"
+    "abbreviation": "COL",
+    "teamColor": "#6F263D"
   },
   {
     "name": "Columbus Blue Jackets",
     "hashtag": "CBJ",
-    "abbreviation": "CBJ"
+    "abbreviation": "CBJ",
+    "teamColor": "#002654"
   },
   {
     "name": "Dallas Stars",
     "hashtag": "TexasHockey",
-    "abbreviation": "DAL"
+    "abbreviation": "DAL",
+    "teamColor": "#006847"
   },
   {
     "name": "Detroit Red Wings",
     "hashtag": "LGRW",
-    "abbreviation": "DET"
+    "abbreviation": "DET",
+    "teamColor": "#CE1126"
   },
   {
     "name": "Edmonton Oilers",
     "hashtag": "LetsGoOilers",
-    "abbreviation": "EDM"
+    "abbreviation": "EDM",
+    "teamColor": "#041E42"
   },
   {
     "name": "Florida Panthers",
     "hashtag": "TimeToHunt",
-    "abbreviation": "FLA"
+    "abbreviation": "FLA",
+    "teamColor": "#041E42"
   },
   {
     "name": "Los Angeles Kings",
     "hashtag": "GoKingsGo",
-    "abbreviation": "LAK"
+    "abbreviation": "LAK",
+    "teamColor": "#111111"
   },
   {
     "name": "Minnesota Wild",
     "hashtag": "MNWild",
-    "abbreviation": "MIN"
+    "abbreviation": "MIN",
+    "teamColor": "#154734"
   },
   {
     "name": "Montreal Canadiens",
     "hashtag": "GoHabsGo",
-    "abbreviation": "MTL"
+    "abbreviation": "MTL",
+    "teamColor": "#AF1E2D"
   },
   {
     "name": "Nashville Predators",
     "hashtag": "Preds",
-    "abbreviation": "NSH"
+    "abbreviation": "NSH",
+    "teamColor": "#FFB81C"
   },
   {
     "name": "New Jersey Devils",
     "hashtag": "NJDevils",
-    "abbreviation": "NJD"
+    "abbreviation": "NJD",
+    "teamColor": "#CE1126"
   },
   {
     "name": "New York Islanders",
     "hashtag": "Isles",
-    "abbreviation": "NYI"
+    "abbreviation": "NYI",
+    "teamColor": "#00539B"
   },
   {
     "name": "New York Rangers",
     "hashtag": "NYR",
-    "abbreviation": "NYR"
+    "abbreviation": "NYR",
+    "teamColor": "#0038A8"
   },
   {
     "name": "Ottawa Senators",
     "hashtag": "GoSensGo",
-    "abbreviation": "OTT"
+    "abbreviation": "OTT",
+    "teamColor": "#C52032"
   },
   {
     "name": "Philadelphia Flyers",
     "hashtag": "LetsGoFlyers",
-    "abbreviation": "PHI"
+    "abbreviation": "PHI",
+    "teamColor": "#F74902"
   },
   {
     "name": "Pittsburgh Penguins",
     "hashtag": "LetsGoPens",
-    "abbreviation": "PIT"
+    "abbreviation": "PIT",
+    "teamColor": "#000000"
   },
   {
     "name": "St. Louis Blues",
     "hashtag": "STLBlues",
-    "abbreviation": "STL"
+    "abbreviation": "STL",
+    "teamColor": "#002F87"
   },
   {
     "name": "San Jose Sharks",
     "hashtag": "SJSharks",
-    "abbreviation": "SJS"
+    "abbreviation": "SJS",
+    "teamColor": "#006D75"
   },
   {
     "name": "Seattle Kraken",
     "hashtag": "SeaKraken",
-    "abbreviation": "SEA"
+    "abbreviation": "SEA",
+    "teamColor": "#001628"
   },
   {
     "name": "Tampa Bay Lightning",
     "hashtag": "GoBolts",
-    "abbreviation": "TBL"
+    "abbreviation": "TBL",
+    "teamColor": "#002868"
   },
   {
     "name": "Toronto Maple Leafs",
     "hashtag": "LeafsForever",
-    "abbreviation": "TOR"
+    "abbreviation": "TOR",
+    "teamColor": "#00205B"
   },
   {
     "name": "Vancouver Canucks",
     "hashtag": "Canucks",
-    "abbreviation": "VAN"
+    "abbreviation": "VAN",
+    "teamColor": "#00205B"
   },
   {
     "name": "Vegas Golden Knights",
     "hashtag": "VegasBorn",
-    "abbreviation": "VGK"
+    "abbreviation": "VGK",
+    "teamColor": "#B4975A"
   },
   {
     "name": "Washington Capitals",
     "hashtag": "ALLCAPS",
-    "abbreviation": "WSH"
+    "abbreviation": "WSH",
+    "teamColor": "#041E42"
   },
   {
     "name": "Winnipeg Jets",
     "hashtag": "GoJetsGo",
-    "abbreviation": "WPG"
+    "abbreviation": "WPG",
+    "teamColor": "#C8102E"
   }
 ]

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ if (!teamList.length) {
  * @param {Buffer} image Image to post
  * @returns
  */
-const postImageToMastodon = (image, message) => new Promise((resolve, reject) => {
+const postImageToMastodon = (image, caption) => new Promise((resolve, reject) => {
   const form = new FormData();
   form.append('file', image, {
     filename: 'image.png',
@@ -62,7 +62,7 @@ const postImageToMastodon = (image, message) => new Promise((resolve, reject) =>
     contentType: 'image/png',
     knownLength: image.length,
   });
-  form.append('description', message);
+  form.append('description', caption);
 
   axios.post(`${MASTODON_BASE_URL}/api/v1/media`, form, {
     headers: {
@@ -164,11 +164,11 @@ const updateOdds = async (teamCode) => {
 
   // Build consolidated message
   let message = `Updated playoff chances for the ${team.name}:\n\n`;
-  if (showSportsClubStatsOdds) {
-    message += `• Sports Club Stats: ${formatOdds(sportsClubStatsOdds)}\n`;
-  }
   if (showMoneyPuckOdds) {
     message += `• MoneyPuck: ${formatOdds(moneyPuckOdds)}\n`;
+  }
+  if (showSportsClubStatsOdds) {
+    message += `• Sports Club Stats: ${formatOdds(sportsClubStatsOdds)}\n`;
   }
   message += `\n\n#NHL #${team.hashtag} #${team.abbreviation} #${team.name.replace(/(\s|\.)/g, '')}`;
   logger.debug(message);
@@ -193,10 +193,11 @@ const updateOdds = async (teamCode) => {
   });
 
   // Post image to Mastodon
+  const caption = `${message}\n\nUpdated ${updatedAt}`;
   logger.info('Posting image to Mastodon ...');
   let media = null;
   try {
-    media = await postImageToMastodon(image, message);
+    media = await postImageToMastodon(image, caption);
     if (media && media.id) {
       logger.info(`Image posted to Mastodon. ID: ${media.id}`);
       logger.debug(media);

--- a/src/utils/imageGenerator.js
+++ b/src/utils/imageGenerator.js
@@ -5,6 +5,7 @@ import logger from './logger.js';
 import { formatOdds } from './text.js';
 
 const { PassThrough } = STREAM;
+const attributionLine = process.env.ATTRIBUTION_LINE || '@hockeybot@botsin.space';
 
 const generateImage = async ({
   team, sportsClubStatsOdds, moneyPuckOdds, updatedAt,
@@ -38,20 +39,20 @@ const generateImage = async ({
     ctx.antialias = 'subpixel';
     ctx.filter = 'none';
 
-    // Box
-    ctx.fillStyle = '#111111';
-    ctx.fillRect(40, 60, 720, 80);
+    // Heading Background Box
+    ctx.fillStyle = team.teamColor || '#111111';
+    ctx.fillRect(40, 40, 720, 80);
 
     // Heading
     ctx.fillStyle = '#FFFFFF';
     ctx.font = '26pt GothicA1-Black';
     ctx.textAlign = 'center';
-    ctx.fontStretch = ctx.fillText((`Playoff odds for the ${team.name}`).toUpperCase(), 400, 110);
+    ctx.fontStretch = ctx.fillText((`Playoff odds for the ${team.name}`).toUpperCase(), 400, 90);
 
     // Team Logo
-    ctx.drawImage(logo, 360, 110, 400, 400);
+    ctx.drawImage(logo, 360, 90, 400, 400);
 
-    let currentYPosition = 200;
+    let currentYPosition = 190;
 
     // MoneyPuck
     if (moneyPuckOdds) {
@@ -62,7 +63,7 @@ const generateImage = async ({
       ctx.fillStyle = '#800000';
       ctx.font = '60pt GothicA1-Black';
       ctx.fillText(formatOdds(moneyPuckOdds), 230, currentYPosition + 70);
-      currentYPosition = 350;
+      currentYPosition = 330;
     }
 
     // Sports Club Stats
@@ -77,13 +78,20 @@ const generateImage = async ({
     }
 
     // Divider
+    ctx.fillStyle = team.teamColor || '#111111';
     ctx.fillRect(40, 480, 720, 2);
+
+    // Credit
+    ctx.fillStyle = '#999999';
+    ctx.font = '16pt GothicA1-Regular';
+    ctx.textAlign = 'left';
+    ctx.fillText(attributionLine, 50, 510);
 
     // Timestamp
     ctx.fillStyle = '#999999';
     ctx.font = '16pt GothicA1-Regular';
-    ctx.textAlign = 'left';
-    ctx.fillText(`Updated ${updatedAt}`, 50, 510);
+    ctx.textAlign = 'right';
+    ctx.fillText(`Updated ${updatedAt}`, 750, 510);
 
     // Return stream of data
     logger.info('Encoding ...');


### PR DESCRIPTION

![b419f0d45f7ca815](https://github.com/stephenyeargin/hockey-bot/assets/80459/2c7e28c5-588d-44ba-9d3e-75f3e91cfaab)

* Adds attribution line
* Uses team colors for heading
* Adjusts layout down a bit on image
* Reorders message to put MoneyPuck first
